### PR TITLE
Ignore "remove a Not Null Constraint" operation

### DIFF
--- a/django_migration_linter/sql_analyser.py
+++ b/django_migration_linter/sql_analyser.py
@@ -37,7 +37,8 @@ migration_tests = (
     {
         "code": "NOT_NULL",
         "fn": lambda sql, **kw: re.search("NOT NULL", sql)
-        and not re.search("CREATE TABLE", sql),
+        and not re.search("CREATE TABLE", sql)
+        and not re.search("(?<=DROP) NOT NULL", sql),
         "err_msg": "NOT NULL constraint on columns",
     },
     {

--- a/django_migration_linter/sql_analyser.py
+++ b/django_migration_linter/sql_analyser.py
@@ -36,9 +36,8 @@ def has_default(sql, **kwargs):
 migration_tests = (
     {
         "code": "NOT_NULL",
-        "fn": lambda sql, **kw: re.search("NOT NULL", sql)
-        and not re.search("CREATE TABLE", sql)
-        and not re.search("(?<=DROP) NOT NULL", sql),
+        "fn": lambda sql, **kw: re.search("(?<!DROP) NOT NULL", sql)
+        and not re.search("CREATE TABLE", sql),
         "err_msg": "NOT NULL constraint on columns",
     },
     {


### PR DESCRIPTION
Remove a Not Null Constraint operation should be safe enough, and
can not affect the migration.

Example:
  ALTER TABLE "table" ALTER COLUMN "column" DROP NOT NULL;